### PR TITLE
Remove parameters like parameter in NewEndpoint

### DIFF
--- a/pkg/resty/resty.go
+++ b/pkg/resty/resty.go
@@ -53,11 +53,10 @@ type Endpoint struct {
 	parameters Parameters
 }
 
-func NewEndpoint(request Request, path string, parameters Parameters) Endpoint {
+func NewEndpoint(request Request, path string) Endpoint {
 	return Endpoint{
-		request:    request,
-		path:       path,
-		parameters: parameters,
+		request: request,
+		path:    path,
 	}
 }
 

--- a/pkg/resty/resty_test.go
+++ b/pkg/resty/resty_test.go
@@ -97,7 +97,7 @@ func TestRequest_Post(t *testing.T) {
 				Log:     LogStub{},
 			}
 
-			endpoint := resty.NewEndpoint(req, "", nil)
+			endpoint := resty.NewEndpoint(req, "")
 
 			tc.args.ctx = addContext(tc.args.ctx)
 
@@ -177,7 +177,7 @@ func TestRequest_Put(t *testing.T) {
 				Headers: tc.fields.headers,
 			}
 
-			endpoint := resty.NewEndpoint(req, "", nil)
+			endpoint := resty.NewEndpoint(req, "")
 
 			got, err := endpoint.Put(tc.args.ctx, tc.args.msg)
 
@@ -276,7 +276,7 @@ func TestRequest_Get(t *testing.T) {
 				Headers: tc.fields.headers,
 			}
 
-			endpoint := resty.NewEndpoint(req, "", nil)
+			endpoint := resty.NewEndpoint(req, "")
 
 			for k, v := range tc.fields.parameters {
 				endpoint.AddParameterValueByKey(k, v)
@@ -340,7 +340,7 @@ func TestRequest_Delete(t *testing.T) {
 				Headers: tc.fields.headers,
 			}
 
-			endpoint := resty.NewEndpoint(req, "", nil)
+			endpoint := resty.NewEndpoint(req, "")
 
 			got, err := endpoint.Delete(tc.args.ctx)
 


### PR DESCRIPTION
Remove parameters like parameter in endpoint constructor, because is not
necesary for instance