### PR TITLE
Fix method to add parameters to endpoint

### DIFF
--- a/pkg/resty/resty.go
+++ b/pkg/resty/resty.go
@@ -20,7 +20,6 @@ type Resty interface {
 	Put(context.Context, []byte) (*http.Response, error)
 	Get(context.Context) (*http.Response, error)
 	Delete(context.Context) (*http.Response, error)
-	BuildParameterWithKeyAndValue(string, string) Endpoint
 }
 
 type Response struct {
@@ -77,7 +76,7 @@ func (e Endpoint) Delete(ctx context.Context) (*http.Response, error) {
 	return e.doRequest(ctx, nil, http.MethodDelete)
 }
 
-func (e Endpoint) BuildParameterWithKeyAndValue(key string, value string) Endpoint {
+func AddParamsToEndpoint(e *Endpoint, key string, value string) {
 	parameters := make(map[string]string)
 	for k, v := range e.parameters {
 		parameters[k] = v
@@ -86,8 +85,6 @@ func (e Endpoint) BuildParameterWithKeyAndValue(key string, value string) Endpoi
 	parameters[key] = value
 
 	e.parameters = parameters
-
-	return e
 }
 
 func (e Endpoint) doRequest(ctx context.Context, msg []byte, method string) (*http.Response, error) {

--- a/pkg/resty/resty_test.go
+++ b/pkg/resty/resty_test.go
@@ -279,7 +279,7 @@ func TestRequest_Get(t *testing.T) {
 			endpoint := resty.NewEndpoint(req, "")
 
 			for k, v := range tc.fields.parameters {
-				endpoint = endpoint.BuildParameterWithKeyAndValue(k, v)
+				resty.AddParamsToEndpoint(&endpoint, k, v)
 			}
 
 			got, err := endpoint.Get(tc.args.ctx)


### PR DESCRIPTION
Change method to add parameters to endpoint, changing the medhot for a
single function that receive the endpoint like a pointer and the params
like key and value